### PR TITLE
Changes to Enemy Possession Logic

### DIFF
--- a/lc-hax/Scripts/Core/InputListener.cs
+++ b/lc-hax/Scripts/Core/InputListener.cs
@@ -17,10 +17,11 @@ class InputListener : MonoBehaviour {
     internal static event Action? OnLeftBracketPress;
     internal static event Action? OnRightBracketPress;
     internal static event Action? OnBackslashPress;
-    internal static event Action? OnZPress;
     internal static event Action? OnDelPress;
+    internal static event Action? OnZPress;
     internal static event Action? OnXPress;
     internal static event Action? OnNPress;
+    internal static event Action? OnQPress;
     internal static event Action? OnUpArrowPress;
     internal static event Action? OnDownArrowPress;
     internal static event Action? OnF4Press;
@@ -45,6 +46,7 @@ class InputListener : MonoBehaviour {
         (() => Keyboard.current[Key.Z].wasPressedThisFrame, () => InputListener.OnZPress?.Invoke()),
         (() => Keyboard.current[Key.X].wasPressedThisFrame, () => InputListener.OnXPress?.Invoke()),
         (() => Keyboard.current[Key.N].wasPressedThisFrame, () => InputListener.OnNPress?.Invoke()),
+        (() => Keyboard.current[Key.Q].wasPressedThisFrame, () => InputListener.OnQPress?.Invoke()),
         (() => Keyboard.current[Key.UpArrow].wasPressedThisFrame, () => InputListener.OnUpArrowPress?.Invoke()),
         (() => Keyboard.current[Key.DownArrow].wasPressedThisFrame, () => InputListener.OnDownArrowPress?.Invoke()),
         (() => Keyboard.current[Key.F4].wasPressedThisFrame, () => InputListener.OnF4Press?.Invoke()),

--- a/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
+++ b/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
@@ -157,6 +157,10 @@ class EnemyPromptHandler {
         dressGirl.SetBehaviourState(BehaviourState.IDLE);
     }
 
+        void HandleDoublewingBird(DoublewingAI doublewingBird, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
+        this.TeleportEnemyToPlayer(doublewingBird, targetPlayer, willTeleportEnemy, true);
+    }
+
     internal void HandleEnemy(EnemyAI enemy, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
         switch (enemy) {
             case CrawlerAI thumper:
@@ -221,6 +225,10 @@ class EnemyPromptHandler {
 
             case DressGirlAI dressGirl:
                 this.HandleDressGirl(dressGirl, targetPlayer, willTeleportEnemy);
+                break;
+
+            case DoublewingAI doublewingBird:
+                this.HandleDoublewingBird(doublewingBird, targetPlayer, willTeleportEnemy);
                 break;
 
             default:

--- a/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
+++ b/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
@@ -161,6 +161,11 @@ class EnemyPromptHandler {
         this.TeleportEnemyToPlayer(doublewingBird, targetPlayer, willTeleportEnemy, true);
     }
 
+        void HandleDocileLocustBees(DocileLocustBeesAI docileLocustBees, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
+        this.TeleportEnemyToPlayer(docileLocustBees, targetPlayer, willTeleportEnemy, true);
+        docileLocustBees.SetBehaviourState(BehaviourState.IDLE);
+    }
+
     internal void HandleEnemy(EnemyAI enemy, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
         switch (enemy) {
             case CrawlerAI thumper:
@@ -229,6 +234,10 @@ class EnemyPromptHandler {
 
             case DoublewingAI doublewingBird:
                 this.HandleDoublewingBird(doublewingBird, targetPlayer, willTeleportEnemy);
+                break;
+
+            case DocileLocustBeesAI docileLocustBees:
+                this.HandleDocileLocustBees(docileLocustBees, targetPlayer, willTeleportEnemy);
                 break;
 
             default:

--- a/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
+++ b/lc-hax/Scripts/Mixins/IEnemyPrompter.cs
@@ -152,6 +152,11 @@ class EnemyPromptHandler {
         earthLeviathan.SetBehaviourState(BehaviourState.CHASE);
     }
 
+    void HandleDressGirl(DressGirlAI dressGirl, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
+        this.TeleportEnemyToPlayer(dressGirl, targetPlayer, willTeleportEnemy, true);
+        dressGirl.SetBehaviourState(BehaviourState.IDLE);
+    }
+
     internal void HandleEnemy(EnemyAI enemy, PlayerControllerB targetPlayer, bool willTeleportEnemy) {
         switch (enemy) {
             case CrawlerAI thumper:
@@ -212,6 +217,10 @@ class EnemyPromptHandler {
 
             case SandWormAI earthLeviathan:
                 this.HandleEarthLeviathan(earthLeviathan, targetPlayer, willTeleportEnemy);
+                break;
+
+            case DressGirlAI dressGirl:
+                this.HandleDressGirl(dressGirl, targetPlayer, willTeleportEnemy);
                 break;
 
             default:

--- a/lc-hax/Scripts/Modules/ESPMod.cs
+++ b/lc-hax/Scripts/Modules/ESPMod.cs
@@ -59,6 +59,8 @@ sealed class ESPMod : MonoBehaviour {
             if (grabbableObject == null) return;
             Vector3 rendererCentrePoint = camera.WorldToEyesPoint(grabbableObject.transform.position);
 
+            if (PossessionMod.Instance is { IsPossessed: true } && !(PossessionMod.Instance is { PossessedEnemy: HoarderBugAI } || PossessionMod.Instance is { PossessedEnemy: BaboonBirdAI })) return;
+            
             if (rendererCentrePoint.z <= 2.0f) {
                 return;
             }

--- a/lc-hax/Scripts/Modules/ESPMod.cs
+++ b/lc-hax/Scripts/Modules/ESPMod.cs
@@ -109,6 +109,7 @@ sealed class ESPMod : MonoBehaviour {
 
         Helper.Enemies.WhereIsNotNull().ForEach(enemy => {
             if (enemy.isEnemyDead) return;
+            if (PossessionMod.Instance is { IsPossessed: true }) return;
             if (enemy is DocileLocustBeesAI or DoublewingAI) return;
 
             Renderer? nullableRenderer = enemy is RedLocustBees or TestEnemy

--- a/lc-hax/Scripts/Modules/ESPMod.cs
+++ b/lc-hax/Scripts/Modules/ESPMod.cs
@@ -109,7 +109,7 @@ sealed class ESPMod : MonoBehaviour {
 
         Helper.Enemies.WhereIsNotNull().ForEach(enemy => {
             if (enemy.isEnemyDead) return;
-            if (PossessionMod.Instance is { IsPossessed: true }) return;
+            if (PossessionMod.Instance?.PossessedEnemy == enemy) return;
             if (enemy is DocileLocustBeesAI or DoublewingAI) return;
 
             Renderer? nullableRenderer = enemy is RedLocustBees or TestEnemy

--- a/lc-hax/Scripts/Modules/Possession/Controllers/BrackenController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/BrackenController.cs
@@ -1,4 +1,5 @@
 using Hax;
+using UnityEngine;
 
 enum BrackenState {
     SCOUTING,
@@ -7,6 +8,29 @@ enum BrackenState {
 }
 
 internal class BrackenController : IEnemyController<FlowermanAI> {
+    public float transitionSpeed = 0f;
+
+    public Vector3 CamOffsets = new(0, 2f, -3f);
+    public Vector3 GetCameraOffset(FlowermanAI enemy) {
+        float targetCamOffsetY, targetCamOffsetZ;
+
+        if (enemy.IsBehaviourState(BrackenState.SCOUTING)) {
+            this.transitionSpeed = 4.0f;
+            targetCamOffsetY = 2f;
+            targetCamOffsetZ = -3f;
+        }
+        else {
+            this.transitionSpeed = 4.0f;
+            targetCamOffsetY = 2.6f;
+            targetCamOffsetZ = -3.2f;
+        }
+
+        this.CamOffsets.y = Mathf.Lerp(this.CamOffsets.y, targetCamOffsetY, Time.deltaTime * this.transitionSpeed);
+        this.CamOffsets.z = Mathf.Lerp(this.CamOffsets.z, targetCamOffsetZ, Time.deltaTime * this.transitionSpeed);
+
+        return this.CamOffsets;
+    }
+    
     bool GetStartingKillAnimationLocalClient(FlowermanAI enemy) => enemy.Reflect().GetInternalField<bool>("startingKillAnimationLocalClient");
 
     void SetStartingKillAnimationLocalClient(FlowermanAI enemy, bool value) => enemy.Reflect().SetInternalField("startingKillAnimationLocalClient", value);

--- a/lc-hax/Scripts/Modules/Possession/Controllers/CoilHeadController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/CoilHeadController.cs
@@ -20,13 +20,15 @@ internal class CoilHeadController : IEnemyController<SpringManAI> {
     void SetTimeSinceHittingPlayer(SpringManAI enemy, float value) =>
         enemy.Reflect().SetInternalField("timeSinceHittingPlayer", value);
 
+    public void UsePrimarySkill(SpringManAI enemy) => enemy.SetBehaviourState(enemy.IsBehaviourState(CoilHeadState.Chase) ? CoilHeadState.Idle : CoilHeadState.Chase);
+
     public void OnSecondarySkillHold(SpringManAI enemy) => enemy.SetAnimationGoServerRpc();
 
     public void ReleaseSecondarySkill(SpringManAI enemy) => enemy.SetAnimationStopServerRpc();
 
-    public bool IsAbleToMove(SpringManAI enemy) => !this.GetStoppingMovement(enemy) || enemy.IsBehaviourState(CoilHeadState.Idle);
+    public bool IsAbleToMove(SpringManAI enemy) => !this.GetStoppingMovement(enemy) || enemy.IsBehaviourState(CoilHeadState.Idle) && enemy.agent.speed >= 0;
 
-    public bool IsAbleToRotate(SpringManAI enemy) => !this.GetStoppingMovement(enemy) || enemy.IsBehaviourState(CoilHeadState.Idle);
+    public bool IsAbleToRotate(SpringManAI enemy) => !this.GetStoppingMovement(enemy) || enemy.IsBehaviourState(CoilHeadState.Idle) && enemy.agent.speed >= 0;
 
     public float InteractRange(SpringManAI _) => 1.5f;
 

--- a/lc-hax/Scripts/Modules/Possession/Controllers/DocileLocustBeesController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/DocileLocustBeesController.cs
@@ -1,0 +1,39 @@
+using Hax;
+using UnityEngine;
+
+enum DocileLocustBeesState {
+    ROAMING,
+    HIDING
+}
+
+internal class DocileLocustBeesController : IEnemyController<DocileLocustBeesAI> {
+
+    Vector3 CamOffset = new Vector3(0, 2f, -4.5f);
+
+    Vector3 EnemyPositionOffset = new Vector3(0, 1.5f, 0);
+
+    public Vector3 GetCameraOffset(DocileLocustBeesAI enemy) => this.CamOffset;
+
+    public Vector3 GetEnemyPositionOffset(DocileLocustBeesAI enemy) => this.EnemyPositionOffset;
+
+    bool IsRoaming = true;
+
+    public void OnPossess(DocileLocustBeesAI enemy) => IsRoaming = true;
+
+    public void UseSecondarySkill(DocileLocustBeesAI enemy) => IsRoaming = false;
+
+    public void ReleaseSecondarySkill(DocileLocustBeesAI enemy) => IsRoaming = true;
+
+    public void Update(DocileLocustBeesAI enemy, bool isAIControlled) {
+        if (isAIControlled) return;
+        if (IsRoaming) {
+            enemy.SetBehaviourState(DocileLocustBeesState.ROAMING);
+        }
+        else {
+            enemy.SetBehaviourState(DocileLocustBeesState.HIDING);
+        }
+    }
+
+    public bool SyncAnimationSpeedEnabled(EnemyAI enemy) => false;
+}
+

--- a/lc-hax/Scripts/Modules/Possession/Controllers/DoublewingBirdController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/DoublewingBirdController.cs
@@ -1,0 +1,41 @@
+using Hax;
+using UnityEngine;
+
+enum DoublewingBirdState {
+    IDLE,
+    GLIDING,
+}
+
+internal class DoublewingBirdController : IEnemyController<DoublewingAI> {
+    public float transitionSpeed = 0f;
+
+    public Vector3 CamOffsets = new(0, 2.3f, -3f);
+    public Vector3 GetCameraOffset(DoublewingAI enemy) {
+        float targetCamOffsetY, targetCamOffsetZ;
+
+        if (enemy.IsBehaviourState(DoublewingBirdState.GLIDING)) { // In Air
+            this.transitionSpeed = 1.2f;
+            targetCamOffsetY = 22.5f;
+            targetCamOffsetZ = -3.5f;
+        }
+        else { // On Ground
+            this.transitionSpeed = 1.3f;
+            targetCamOffsetY = 2.3f;
+            targetCamOffsetZ = -3f;
+        }
+
+        this.CamOffsets.y = Mathf.Lerp(this.CamOffsets.y, targetCamOffsetY, Time.deltaTime * this.transitionSpeed);
+        this.CamOffsets.z = Mathf.Lerp(this.CamOffsets.z, targetCamOffsetZ, Time.deltaTime * this.transitionSpeed);
+
+        return this.CamOffsets;
+    }
+
+    public void UsePrimarySkill(DoublewingAI enemy) => enemy.SetBehaviourState(DoublewingBirdState.IDLE);
+
+    public void UseSecondarySkill(DoublewingAI enemy) => enemy.SetBehaviourState(DoublewingBirdState.GLIDING);
+
+    public bool IsAbleToRotate(EnemyAI enemy) => !enemy.IsBehaviourState(DoublewingBirdState.IDLE);
+
+    public bool SyncAnimationSpeedEnabled(DoublewingAI enemy) => true;
+}
+

--- a/lc-hax/Scripts/Modules/Possession/Controllers/DressGirlController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/DressGirlController.cs
@@ -1,0 +1,114 @@
+using GameNetcodeStuff;
+using Hax;
+using Unity.Netcode;
+using UnityEngine;
+
+enum DressGirlState {
+    PEACAFUL,
+    HOSTEL,
+}
+
+internal class DressGirlController : IEnemyController<DressGirlAI> {
+
+    bool IsVisible { get; set; } = false;
+    bool IsChasing { get; set; } = false;
+    bool IsStalking { get; set; } = false;
+
+    public void UsePrimarySkill(DressGirlAI enemy) {
+        if (IsChasing) return;
+        IsVisible = true;
+        IsChasing = true;
+    }
+
+    public void UseSecondarySkill(DressGirlAI enemy) {
+        IsVisible = true;
+        IsStalking = true;
+    }
+
+    public void ReleaseSecondarySkill(DressGirlAI enemy) {
+        IsVisible = false;
+        IsChasing = false;
+        IsStalking = false;
+    }
+
+    public void OnMovement(DressGirlAI enemy, bool isMoving, bool isSprinting) {
+        if (!IsVisible) return;
+        if (isMoving) {
+        }
+        else {
+        }
+    }
+
+    public void Update(DressGirlAI enemy, bool isAIControlled) {
+        PlayerControllerB hostPlayer = Helper.Players[0]; // For Testing
+        enemy.hauntingPlayer = hostPlayer;
+
+        if (IsChasing) {
+            enemy.SetBehaviourState(DressGirlState.HOSTEL);
+        }
+        else {
+            enemy.SetBehaviourState(DressGirlState.PEACAFUL);
+        }
+
+        if (IsVisible) {
+            ClientSideIsVisible(enemy);
+        }
+        else {
+            ClientSideIsNotVisible(enemy);
+        }
+    }
+
+    internal static void SendUITip(string header, string message, bool warning) {
+        HUDManager.Instance?.DisplayTip(header, message, warning, false, "LC_Tip1");
+    }
+
+    public void OnPossess(DressGirlAI enemy) => ClientSideIsNotVisible(enemy);
+
+    public void OnUnpossess(DressGirlAI enemy) {
+        ReleaseSecondarySkill(enemy);
+        ClientSetInvisible(enemy);
+    }
+
+    void ClientSideIsVisible(DressGirlAI enemy) {
+        for (int Body = 0; Body < enemy.skinnedMeshRenderers.Length; Body++) {
+            enemy.skinnedMeshRenderers[Body].gameObject.layer = 19;
+            enemy.skinnedMeshRenderers[Body].material.color = new Color(1f, 1f, 1f);
+        }
+        for (int Eyes = 0; Eyes < enemy.meshRenderers.Length; Eyes++) {
+            enemy.meshRenderers[Eyes].gameObject.layer = 19;
+            enemy.meshRenderers[Eyes].material.color = new Color(1f, 1f, 1f);
+        }
+    }
+
+    void ClientSideIsNotVisible(DressGirlAI enemy) {
+        for (int Body = 0; Body < enemy.skinnedMeshRenderers.Length; Body++) {
+            enemy.skinnedMeshRenderers[Body].gameObject.layer = 19;
+            enemy.skinnedMeshRenderers[Body].material.color = new Color(0f, 0f, 0f);
+        }
+        for (int Eyes = 0; Eyes < enemy.meshRenderers.Length; Eyes++) {
+            enemy.meshRenderers[Eyes].gameObject.layer = 19;
+            enemy.meshRenderers[Eyes].material.color = new Color(0f, 0f, 0f);
+        }
+    }
+
+    void ClientSetInvisible(DressGirlAI enemy) {
+        for (int Body = 0; Body < enemy.skinnedMeshRenderers.Length; Body++) {
+            enemy.skinnedMeshRenderers[Body].gameObject.layer = 23;
+            enemy.skinnedMeshRenderers[Body].material.color = new Color(1f, 1f, 1f);
+        }
+        for (int Eyes = 0; Eyes < enemy.meshRenderers.Length; Eyes++) {
+            enemy.meshRenderers[Eyes].gameObject.layer = 23;
+            enemy.meshRenderers[Eyes].material.color = new Color(1f, 1f, 1f);
+        }
+    }
+
+    public string GetPrimarySkillName(DressGirlAI enemy) => enemy.IsBehaviourState(DressGirlState.HOSTEL) ? "" : "Chase";
+
+    public string GetSecondarySkillName(DressGirlAI enemy) => enemy.IsBehaviourState(DressGirlState.HOSTEL) ? "Stop Chasing" : "(HOLD) Show";
+
+    public bool CanUseEntranceDoors(DressGirlAI _) => true;
+
+    public float InteractRange(DressGirlAI _) => 1.0f;
+
+    public bool SyncAnimationSpeedEnabled(DressGirlAI _) => true;
+}

--- a/lc-hax/Scripts/Modules/Possession/Controllers/DressGirlController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/DressGirlController.cs
@@ -58,10 +58,6 @@ internal class DressGirlController : IEnemyController<DressGirlAI> {
         }
     }
 
-    internal static void SendUITip(string header, string message, bool warning) {
-        HUDManager.Instance?.DisplayTip(header, message, warning, false, "LC_Tip1");
-    }
-
     public void OnPossess(DressGirlAI enemy) => ClientSideIsNotVisible(enemy);
 
     public void OnUnpossess(DressGirlAI enemy) {

--- a/lc-hax/Scripts/Modules/Possession/Controllers/EarthLeviathanController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/EarthLeviathanController.cs
@@ -13,6 +13,10 @@ internal class EarthLeviathanController : IEnemyController<SandWormAI> {
         enemy.StartEmergeAnimation();
     }
 
+    public bool IsAbleToMove(SandWormAI enemy) => enemy.inSpecialAnimation ? false : true;
+
+    public bool IsAbleToRotate(SandWormAI enemy) => enemy.inSpecialAnimation ? false : true;
+
     public string GetSecondarySkillName(SandWormAI _) => "Emerge";
 
     public bool CanUseEntranceDoors(SandWormAI _) => false;

--- a/lc-hax/Scripts/Modules/Possession/Controllers/IEnemyController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/IEnemyController.cs
@@ -29,6 +29,8 @@ internal interface IController {
 
     void ReleaseSecondarySkill(EnemyAI enemy);
 
+    void UseSpecialAbility(EnemyAI enemy);
+
     void OnMovement(EnemyAI enemy, bool isMoving, bool isSprinting);
 
     bool IsAbleToMove(EnemyAI enemy);
@@ -67,6 +69,8 @@ internal interface IEnemyController<T> : IController where T : EnemyAI {
     void UseSecondarySkill(T enemy) { }
 
     void ReleaseSecondarySkill(T enemy) { }
+
+    void UseSpecialAbility(T enemy) {  }
 
     void OnMovement(T enemy, bool isMoving, bool isSprinting) { }
 
@@ -107,6 +111,8 @@ internal interface IEnemyController<T> : IController where T : EnemyAI {
     void IController.UseSecondarySkill(EnemyAI enemy) => this.UseSecondarySkill((T)enemy);
 
     void IController.ReleaseSecondarySkill(EnemyAI enemy) => this.ReleaseSecondarySkill((T)enemy);
+
+    void IController.UseSpecialAbility(EnemyAI enemy) => this.UseSpecialAbility((T)enemy);
 
     void IController.OnMovement(EnemyAI enemy, bool isMoving, bool isSprinting) => this.OnMovement((T)enemy, isMoving, isSprinting);
 

--- a/lc-hax/Scripts/Modules/Possession/Controllers/MaskedController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/MaskedController.cs
@@ -10,9 +10,14 @@ internal class MaskedPlayerController : IEnemyController<MaskedPlayerEnemy> {
         enemy.Reflect().SetInternalField("startingKillAnimationLocalClient", value);
 
     bool GetinKillAnimation(MaskedPlayerEnemy enemy) => enemy.Reflect().GetInternalField<bool>("inKillAnimation");
+
     public void UsePrimarySkill(MaskedPlayerEnemy enemy) => enemy.SetHandsOutServerRpc(!enemy.creatureAnimator.GetBool("HandsOut"));
 
     public void UseSecondarySkill(MaskedPlayerEnemy enemy) => enemy.SetCrouchingServerRpc(!enemy.creatureAnimator.GetBool("Crouching"));
+
+    public bool IsAbleToMove(EnemyAI enemy) => enemy.Reflect().GetInternalField<bool>("inKillAnimation") ? false : true;
+
+    public bool IsAbleToRotate(EnemyAI enemy) => enemy.Reflect().GetInternalField<bool>("inKillAnimation") ? false : true;
 
     public float InteractRange(MaskedPlayerEnemy _) => 1.0f;
 

--- a/lc-hax/Scripts/Modules/Possession/Controllers/NutcrackerController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/NutcrackerController.cs
@@ -54,6 +54,8 @@ internal class NutcrackerController : IEnemyController<NutcrackerEnemyAI> {
         this.InSentryMode = false;
     }
 
+    public void UseSpecialAbility(NutcrackerEnemyAI enemy) => enemy.ReloadGunServerRpc();
+
     public void OnUnpossess(NutcrackerEnemyAI enemy) => this.InSentryMode = false;
 
     public string GetPrimarySkillName(NutcrackerEnemyAI enemy) => enemy.gun is null ? "" : "Fire";

--- a/lc-hax/Scripts/Modules/Possession/Controllers/SnareFleaController.cs
+++ b/lc-hax/Scripts/Modules/Possession/Controllers/SnareFleaController.cs
@@ -18,12 +18,17 @@ internal class SnareFleaController : IEnemyController<CentipedeAI> {
     public Vector3 GetCameraOffset(CentipedeAI enemy) {
         float targetCamOffsetY, targetCamOffsetZ;
 
-        if (!enemy.IsBehaviourState(SnareFleaState.HIDING)) {
+        if (!enemy.IsBehaviourState(SnareFleaState.HIDING) && enemy.clingingToPlayer is null) { // Is Roaming
             this.transitionSpeed = 8.0f;
             targetCamOffsetY = 2f;
             targetCamOffsetZ = -4f;
         }
-        else {
+        else if (enemy.clingingToPlayer is not null) { // On Player
+            this.transitionSpeed = 4.5f;
+            targetCamOffsetY = 0f;
+            targetCamOffsetZ = -2f;
+        }
+        else { // On Ceiling
             this.transitionSpeed = 2.5f;
             targetCamOffsetY = -0.3f;
             targetCamOffsetZ = 0f;

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -76,6 +76,7 @@ internal sealed class PossessionMod : MonoBehaviour {
         InputListener.OnLeftButtonPress += this.UsePrimarySkill;
         InputListener.OnRightButtonPress += this.UseSecondarySkill;
         InputListener.OnRightButtonRelease += this.ReleaseSecondarySkill;
+        InputListener.OnQPress += this.UseSpecialAbility;
         InputListener.OnRightButtonHold += this.OnRightMouseButtonHold;
         InputListener.OnDelPress += this.KillEnemyAndUnposses;
         InputListener.OnF9Press += this.ToggleAIControl;
@@ -89,6 +90,7 @@ internal sealed class PossessionMod : MonoBehaviour {
         InputListener.OnLeftButtonPress -= this.UsePrimarySkill;
         InputListener.OnRightButtonPress -= this.UseSecondarySkill;
         InputListener.OnRightButtonRelease -= this.ReleaseSecondarySkill;
+        InputListener.OnQPress -= this.UseSpecialAbility;
         InputListener.OnRightButtonHold -= this.OnRightMouseButtonHold;
         InputListener.OnDelPress -= this.KillEnemyAndUnposses;
         InputListener.OnF9Press -= this.ToggleAIControl;
@@ -443,5 +445,12 @@ internal sealed class PossessionMod : MonoBehaviour {
         if (!this.EnemyControllers.TryGetValue(enemy.GetType(), out IController controller)) return;
 
         controller.ReleaseSecondarySkill(enemy);
+    }
+
+    void UseSpecialAbility() {
+        if (this.Possession.Enemy is not EnemyAI enemy) return;
+        if (!this.EnemyControllers.TryGetValue(enemy.GetType(), out IController controller)) return;
+
+        controller.UseSpecialAbility(enemy);
     }
 }

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -234,7 +234,8 @@ internal sealed class PossessionMod : MonoBehaviour {
             : Quaternion.LookRotation(enemy.transform.forward);
 
         // Set the camera rotation without changing its position
-        camera.transform.rotation = newRotation;
+        float RotationLerpSpeed = 0.6f;
+        camera.transform.rotation = Quaternion.Lerp(camera.transform.rotation, newRotation, RotationLerpSpeed);
     }
 
     void UpdateEnemyRotation() {

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -45,7 +45,8 @@ internal sealed class PossessionMod : MonoBehaviour {
         { typeof(SandSpiderAI), new BunkerSpiderController() },
         { typeof(RedLocustBees), new CircuitBeesController() },
         { typeof(DressGirlAI), new DressGirlController() },
-        { typeof(DoublewingAI), new DoublewingBirdController() }
+        { typeof(DoublewingAI), new DoublewingBirdController() },
+        { typeof(DocileLocustBeesAI), new DocileLocustBeesController() }
     };
 
     float DoorCooldownRemaining { get; set; } = 0.0f;

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -44,7 +44,8 @@ internal sealed class PossessionMod : MonoBehaviour {
         { typeof(CrawlerAI), new CrawlerController() },
         { typeof(SandSpiderAI), new BunkerSpiderController() },
         { typeof(RedLocustBees), new CircuitBeesController() },
-        { typeof(DressGirlAI), new DressGirlController() }
+        { typeof(DressGirlAI), new DressGirlController() },
+        { typeof(DoublewingAI), new DoublewingBirdController() }
     };
 
     float DoorCooldownRemaining { get; set; } = 0.0f;

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -205,9 +205,10 @@ internal sealed class PossessionMod : MonoBehaviour {
         }
 
         if (controller.IsAbleToMove(enemy)) {
-            this.UpdateEnemyPosition(enemy);
             controller.OnMovement(enemy, this.CharacterMovement.IsMoving, this.CharacterMovement.IsSprinting);
         }
+
+        this.UpdateEnemyPosition(enemy);
 
         if (controller.IsAbleToRotate(enemy)) {
             this.UpdateEnemyRotation();

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -208,6 +208,8 @@ internal sealed class PossessionMod : MonoBehaviour {
             controller.OnMovement(enemy, this.CharacterMovement.IsMoving, this.CharacterMovement.IsSprinting);
         }
 
+        if (!controller.IsAbleToMove(enemy) && PossessedEnemy != null && PossessedEnemy.GetType() == typeof(CentipedeAI)) return;
+
         this.UpdateEnemyPosition(enemy);
 
         if (controller.IsAbleToRotate(enemy)) {

--- a/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
+++ b/lc-hax/Scripts/Modules/Possession/PossessionMod.cs
@@ -43,7 +43,8 @@ internal sealed class PossessionMod : MonoBehaviour {
         { typeof(LassoManAI), new LassoManController() },
         { typeof(CrawlerAI), new CrawlerController() },
         { typeof(SandSpiderAI), new BunkerSpiderController() },
-        { typeof(RedLocustBees), new CircuitBeesController() }
+        { typeof(RedLocustBees), new CircuitBeesController() },
+        { typeof(DressGirlAI), new DressGirlController() }
     };
 
     float DoorCooldownRemaining { get; set; } = 0.0f;

--- a/lc-hax/Scripts/Modules/TriggerMod.cs
+++ b/lc-hax/Scripts/Modules/TriggerMod.cs
@@ -83,7 +83,7 @@ sealed class TriggerMod : MonoBehaviour, IEnemyPrompter {
                 break;
             }
 
-            if (collider.GetComponentInParent<EnemyAI>().Unfake() is EnemyAI enemy && Setting.EnablePhantom) {
+            if (collider.GetComponentInParent<EnemyAI>().Unfake() is EnemyAI enemy && Setting.EnablePhantom && PossessionMod.Instance?.PossessedEnemy != enemy) {
                 PossessionMod.Instance?.Possess(enemy);
                 break;
             }


### PR DESCRIPTION
# This Pull Request aims to improve a lot of The Possession Logic for all of the enemies
## New
- Added a third ability called `UseSpecialAbility()` which is called by pressing `Q`
- Added a template for the ghost girl controller, it is not finished at all it's just a quick template with all the necessary code.
- Added DoublewingBird Controller.
- Added DocileLocustBees Controller.

## Changes
1. The Nutcracker now has to reload when is out of ammo for realism.
2. The Earth Leviathan now cannot move while emerging.
3. The Masked Enemy now can not move while in the killing animation.
4. Better logic for the Coil Head's movement, Also made it where you can change states with the primary ability.
5. The SnareFlea's camera now adjusts when attached to an player.
6. Bracken's camera now adjust depending on State.
7. The Nutcracker now has a special ability to reload.
8. Enemy ESP no longer shows on possessed enemy.
9. Item ESP disabled when possessing unless is HoarderBug/BaboonBirdAI

### And More To Come Soon!